### PR TITLE
[GEN-230] 한국어 출력시 오답 처리되는 문제 해결

### DIFF
--- a/server/judge_client.py
+++ b/server/judge_client.py
@@ -11,6 +11,11 @@ import psutil
 from config import TEST_CASE_DIR, JUDGER_RUN_LOG_PATH, RUN_GROUP_GID, RUN_USER_UID, SPJ_EXE_DIR, SPJ_USER_UID, SPJ_GROUP_GID, RUN_GROUP_GID
 from exception import JudgeClientError
 from utils import ProblemIOMode
+import sys
+import io
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
 
 SPJ_WA = 1
 SPJ_AC = 0
@@ -61,16 +66,15 @@ class JudgeClient(object):
     def _compare_output(self, test_case_file_id, user_output_file):
         with open(user_output_file, "rb") as f:
             content = f.read()
-
-        content = str(content)[2:-1] # str로 변경 
-        content_list = content.split('\\n') # 문자열을 줄바꿈 마다 split
+        content = str(content, 'utf-8') # str로 변경 
+        content_list = content.split('\n') # 문자열을 줄바꿈 마다 split
         new_content_list = []
         for line in content_list :
             new_content_list.append(line.rstrip()) # 각 행마다 rstrip()함수로 오른쪽 여백 제거
         content = '\n'.join(new_content_list).encode('utf-8') # 리스트를 문자열로 변경 후 utf-8로 인코딩
         output_md5 = hashlib.md5(content.rstrip()).hexdigest()
         result = output_md5 == self._get_test_case_file_info(test_case_file_id)["stripped_output_md5"]
-      
+        
         return output_md5, result
 
     def _spj(self, in_file_path, user_out_file_path):


### PR DESCRIPTION
bytes형을 문자열로 디코딩 하는 과정에서 문제가 있었음.

content = str(content)[2:-1] # str로 변경 

이렇게 문자열로 디코딩하면 한글과 같은 멀티 바이트 문자 인코딩을 사용하는 문자열을 포함하고 있을 때 데이터가 손실될 수 있음

그래서 아래와 같은 방법으로 디코딩 해야 함.

content = str(content, 'utf-8') # str로 변경 