### PR TITLE
[GEN-992] _compare_output 줄별 rstrip 롤백 - .out 줄 끝 공백 WA 버그 수정

### DIFF
--- a/server/judge_client.py
+++ b/server/judge_client.py
@@ -67,12 +67,6 @@ class JudgeClient(object):
     def _compare_output(self, test_case_file_id, user_output_file):
         with open(user_output_file, "rb") as f:
             content = f.read()
-        content = str(content, 'utf-8') # str로 변경 
-        content_list = content.split('\n') # 문자열을 줄바꿈 마다 split
-        new_content_list = []
-        for line in content_list :
-            new_content_list.append(line.rstrip()) # 각 행마다 rstrip()함수로 오른쪽 여백 제거
-        content = '\n'.join(new_content_list).encode('utf-8') # 리스트를 문자열로 변경 후 utf-8로 인코딩
         output_md5 = hashlib.md5(content.rstrip()).hexdigest()
         result = output_md5 == self._get_test_case_file_info(test_case_file_id)["stripped_output_md5"]
         return output_md5, result


### PR DESCRIPTION
채점기가 사용자 출력을 줄마다 rstrip()으로 정규화한 뒤 md5를 비교하는데,
백엔드 측 stripped_output_md5는 파일 전체 rstrip만 적용해 계산되어 문제 발생함. 이로 인해 .out 파일에 줄 끝 공백이 있는 정답(예: test011)은 사용자가 .out 내용을 그대로 출력해도 항상 WA 처리됨.

_compare_output을 e36d943 이전 버전(md5(content.rstrip()) 한 줄)으로 되돌려 업로드/채점 양측의 정규화 규칙을 다시 대칭으로 맞춤.

원인 커밋:
- e36d943 (2023-12-15) 줄별 rstrip 최초 도입
- 884b935 (2024-03-16) 일시적 revert
- fe1a6d0 (2024-03-16) 한글 디코딩 수정과 함께 재도입
- master 진입: 8150302 PR #8 (2026-05-14)